### PR TITLE
Scaffold form filler bot with Convex integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# srajob
+
+Utilities for job scraping and application automation.
+
+## form-filler-bot
+
+The form-filler bot reads a user's `resume.yaml` and, when a job application has been queued, operates on the job application link.
+Resume data and queued applications are stored in the Convex database. The actual form-filling behavior is not yet implemented.

--- a/form_filler_bot/__init__.py
+++ b/form_filler_bot/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for the form filler bot."""

--- a/form_filler_bot/bot.py
+++ b/form_filler_bot/bot.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+import yaml
+
+
+class FormFillerBot:
+    """Handles resume data and job application queueing."""
+
+    def __init__(self, convex_url: str) -> None:
+        self.convex_url = convex_url.rstrip("/")
+
+    def load_resume(self, path: Path) -> Dict[str, Any]:
+        """Load resume information from a YAML file."""
+        with path.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+
+    def store_resume(self, resume: Dict[str, Any]) -> None:
+        """Send resume data to the convex backend."""
+        httpx.post(f"{self.convex_url}/api/resume", json=resume)
+
+    def queue_application(self, job_url: str) -> None:
+        """Queue a job application for form filling."""
+        httpx.post(
+            f"{self.convex_url}/api/form-fill/queue", json={"jobUrl": job_url}
+        )
+
+    def next_application(self) -> Optional[Dict[str, Any]]:
+        """Fetch the next queued job application, if any."""
+        resp = httpx.get(f"{self.convex_url}/api/form-fill/next")
+        if resp.status_code != 200 or not resp.content:
+            return None
+        data = resp.json()
+        return data or None

--- a/job_board_application/convex/_generated/api.d.ts
+++ b/job_board_application/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as auth from "../auth.js";
+import type * as formFiller from "../formFiller.js";
 import type * as http from "../http.js";
 import type * as jobs from "../jobs.js";
 import type * as router from "../router.js";
@@ -29,6 +30,7 @@ import type * as seedData from "../seedData.js";
  */
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
+  formFiller: typeof formFiller;
   http: typeof http;
   jobs: typeof jobs;
   router: typeof router;

--- a/job_board_application/convex/formFiller.ts
+++ b/job_board_application/convex/formFiller.ts
@@ -1,0 +1,72 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+export const storeResume = mutation({
+  args: { resume: v.any() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const existing = await ctx.db
+      .query("resumes")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, { data: args.resume });
+    } else {
+      await ctx.db.insert("resumes", { userId, data: args.resume });
+    }
+    return null;
+  },
+});
+
+export const queueApplication = mutation({
+  args: { jobUrl: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    await ctx.db.insert("form_fill_queue", {
+      userId,
+      jobUrl: args.jobUrl,
+      status: "pending",
+      queuedAt: Date.now(),
+    });
+    return null;
+  },
+});
+
+export const nextApplication = query({
+  args: {},
+  returns: v.union(
+    v.null(),
+    v.object({ _id: v.id("form_fill_queue"), jobUrl: v.string() })
+  ),
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const next = await ctx.db
+      .query("form_fill_queue")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .filter((q) => q.eq(q.field("status"), "pending"))
+      .order("asc")
+      .first();
+
+    if (!next) {
+      return null;
+    }
+
+    return { _id: next._id, jobUrl: next.jobUrl };
+  },
+});

--- a/job_board_application/convex/router.ts
+++ b/job_board_application/convex/router.ts
@@ -245,6 +245,61 @@ http.route({
   }),
 });
 
+/**
+ * API endpoint to store a user's resume
+ *
+ * POST /api/resume
+ * Body: resume object
+ */
+http.route({
+  path: "/api/resume",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const resume = await request.json();
+    await ctx.runMutation(api.formFiller.storeResume, { resume });
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }),
+});
+
+/**
+ * API endpoint to queue a job application for form filling
+ *
+ * POST /api/form-fill/queue
+ * Body: { jobUrl: string }
+ */
+http.route({
+  path: "/api/form-fill/queue",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const body = await request.json();
+    await ctx.runMutation(api.formFiller.queueApplication, { jobUrl: body.jobUrl });
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }),
+});
+
+/**
+ * API endpoint to fetch the next queued job application
+ *
+ * GET /api/form-fill/next
+ */
+http.route({
+  path: "/api/form-fill/next",
+  method: "GET",
+  handler: httpAction(async (ctx) => {
+    const next = await ctx.runQuery(api.formFiller.nextApplication, {});
+    return new Response(JSON.stringify(next), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }),
+});
+
 export const insertScrapeRecord = mutation({
   args: {
     sourceUrl: v.string(),

--- a/job_board_application/convex/schema.ts
+++ b/job_board_application/convex/schema.ts
@@ -52,6 +52,18 @@ const applicationTables = {
     completedAt: v.number(),
     items: v.any(),
   }).index("by_source", ["sourceUrl"]),
+
+  resumes: defineTable({
+    userId: v.id("users"),
+    data: v.any(),
+  }).index("by_user", ["userId"]),
+
+  form_fill_queue: defineTable({
+    userId: v.id("users"),
+    jobUrl: v.string(),
+    status: v.union(v.literal("pending"), v.literal("completed")),
+    queuedAt: v.number(),
+  }).index("by_user", ["userId"]),
 };
 
 export default defineSchema({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "httpx>=0.28.1",
     "pydantic>=2.11.7",
     "python-dotenv>=1.1.1",
+    "pyyaml>=6.0.2",
     "temporalio==1.17.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -2120,6 +2120,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "temporalio" },
 ]
 
@@ -2137,6 +2138,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "temporalio", specifier = "==1.17.0" },
 ]


### PR DESCRIPTION
## Summary
- add form_filler_bot with utilities to load resume data and queue job applications
- extend Convex schema and functions to store resumes and queue form-fill tasks
- expose HTTP endpoints for resume storage and form-fill queue
- document form-filler-bot purpose and add PyYAML dependency

## Testing
- `uv run --extra dev ruff check form_filler_bot`
- `uv run --extra dev pytest`
- `npm run lint` *(fails: Convex CLI prompts for login)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9859c0a083239db7c83f2306f546